### PR TITLE
Fix print func usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Simple Example:
 
     from pyXSteam.XSteam import XSteam
     steamTable = XSteam(XSteam.UNIT_SYSTEM_MKS)
-    print steamTable.hL_p(220.0)
+    print(steamTable.hL_p(220.0))
 
 By using the unitSystem Parameter, you can tell XSteam witch Unit System you are using.
 


### PR DESCRIPTION
README says the package aims for usage in python 3.6+, but `print` function applied in the example is in python 2 style 😕 just a minor correction